### PR TITLE
Wifi: Ignore p2p group with null ssid when loadGroups

### DIFF
--- a/service/java/com/android/server/wifi/WifiStateMachine.java
+++ b/service/java/com/android/server/wifi/WifiStateMachine.java
@@ -1699,9 +1699,9 @@ public class WifiStateMachine extends StateMachine {
         int supportedFeatureSet = resultMsg.arg1;
         resultMsg.recycle();
 
-        // Mask the feature set against system properties.
-        boolean disableRtt = mPropertyService.getBoolean("config.disable_rtt", false);
-        if (disableRtt) {
+        boolean checkRtt = mContext.getPackageManager().hasSystemFeature(
+                PackageManager.FEATURE_WIFI_RTT);
+        if (!checkRtt) {
             supportedFeatureSet &=
                     ~(WifiManager.WIFI_FEATURE_D2D_RTT | WifiManager.WIFI_FEATURE_D2AP_RTT);
         }

--- a/service/java/com/android/server/wifi/p2p/SupplicantP2pIfaceHal.java
+++ b/service/java/com/android/server/wifi/p2p/SupplicantP2pIfaceHal.java
@@ -1959,6 +1959,9 @@ public class SupplicantP2pIfaceHal {
                         && !resultSsid.getResult().isEmpty()) {
                     group.setNetworkName(NativeUtil.removeEnclosingQuotes(
                             NativeUtil.encodeSsid(resultSsid.getResult())));
+                } else {
+                    Log.e(TAG, "group ssid is invalid! resultSsid = " + resultSsid);
+                    continue;
                 }
 
                 SupplicantResult<byte[]> resultBssid =


### PR DESCRIPTION
After p2p group created, if invitation comes from another device,
supplicant will create a temporary group with null ssid for wps, this
group will be loaded into frameworks. If Settings GUI query for the
available groups, Settings will stop when it receives the null ssid
group. Hence framework shall ignore the p2p group with null ssid when
loadGroups.